### PR TITLE
add attributes config url

### DIFF
--- a/build/api.json
+++ b/build/api.json
@@ -1,5 +1,6 @@
 {
   "PROPERTIES": "https://raw.githubusercontent.com/togodx/togodx-config-human/develop/config/properties.json",
   "TEMPLATES": "https://raw.githubusercontent.com/togodx/togodx-config-human/develop/config/templates.json",
-  "AGGREGATE": "https://raw.githubusercontent.com/togodx/togodx-config-human/develop/config/aggregate.json"
+  "AGGREGATE": "https://raw.githubusercontent.com/togodx/togodx-config-human/develop/config/aggregate.json",
+  "ATTRIBUTES": "https://raw.githubusercontent.com/togodx/togodx-config-human/main/config/attributes.json"
 }


### PR DESCRIPTION
- `select target database` の欄をカテゴリ (e.g. `Gene (hgnc)`) から、データセット (e.g. `ensembl_gene`) に置き換える
- 選択できるデータセットは `api.json` で参照する `attributes.json` の `.datasets` から選ぶ
  - `"target": true` になっているものだけ
  - `"examples"` に入っている ID を map your ids に表示する
- ついでに
  - placeholder で入っている example をそのまま入力したいときに覚えて手入力しないといけないので不便
  - examples を挿入するためのリンクもしくはボタンを設置するのがよさそう
    - 下のボタンに並べると混乱するので `optional` を左に寄せて右寄せで `examples` と text link を置くのがいいかも

```
  "datasets": {
    "ensembl_gene": {
      "label": "Ensembl gene",
      "template": "https://raw.githubusercontent.com/togodx/togodx-config-human/develop/templates/ensembl_gene.hbs",
      "target": true,
      "examples": [
        "ENSG00000186283",
        "ENSAMEG00000018238",
        "ENSG00000167916",
        "ENSG00000213417",
        "ENSG00000133328"
      ],
```