### PR TITLE
Bugfix/fix-zero-color-search

### DIFF
--- a/source/js/classes/CategoryBrowserView/CategoryBrowserView.js
+++ b/source/js/classes/CategoryBrowserView/CategoryBrowserView.js
@@ -118,6 +118,9 @@ export class CategoryBrowserView extends observeState(LitElement) {
     const parentsArr = incomingData.parents;
 
     const getColor = (datum, max) => {
+      if (datum.count === 0) {
+        return App.colorGray.toString();
+      }
       return `rgb(${this.#categoryColor
         .mix(
           App.colorWhite,


### PR DESCRIPTION
- Count = 0 の場合のノードの色をブラックじゃなくて、グレーに変更
<img width="562" alt="image" src="https://github.com/togodx/togodx-app/assets/55772081/f006c087-b85d-4dfe-9932-db641cec0be7">
